### PR TITLE
bug fix unicode warning

### DIFF
--- a/src/roam/mainwindow.py
+++ b/src/roam/mainwindow.py
@@ -677,7 +677,7 @@ class MainWindow(mainwindow_widget, mainwindow_base):
                 try:
                     layer = QgsMapLayerRegistry.instance().mapLayersByName(layername)[0]
                 except IndexError:
-                    roam.utils.warning("Can't find QGIS layer for select layer {}".format(layername))
+                    roam.utils.warning(u"Can't find QGIS layer for select layer {}".format(layername))
                     continue
                 selectionlayers.append(layer)
 


### PR DESCRIPTION
If I have a layer Name with an Umlaut, and I mess up the QGIS layer, the warning "Can't find QGIS layer for select layer{}" throws a Unicode exception.  Changed string to Unicode so that the warning prints normally.  (Look Ma, no line ending Errors today!)
