### PR TITLE
Set Log path relative to apppath (Linux)

### DIFF
--- a/run_linux.sh
+++ b/run_linux.sh
@@ -2,4 +2,5 @@
 
 DIR="$( cd "$( dirname "$0")" && pwd )" 
 export QGIS_PREFIX_PATH=/usr/
-python $DIR/src/roam/
+export ROAM_APPPATH=$DIR
+python $DIR/src/roam/ $DIR/src/projects

--- a/src/configmanager/logger.py
+++ b/src/configmanager/logger.py
@@ -7,11 +7,7 @@ try:
    logpath = os.path.join(os.environ['ROAM_APPPATH'], 'log')
 except KeyError:
    #running from source
-   logpath = os.path.join(
-                os.path.dirname(
-                   os.path.dirname(
-                      os.path.dirname(
-                         os.path.realpath(__file__)))), 'log')
+   logpath = 'log'
 if not os.path.exists(logpath):
    os.makedirs(logpath)
 LOG_FILENAME = os.path.join(logpath, "{}_configmanager.log".format(getpass.getuser()))

--- a/src/roam/utils.py
+++ b/src/roam/utils.py
@@ -12,12 +12,7 @@ from PyQt4.QtGui import (QLabel, QDialog, QGridLayout, QLayout)
 try:
    logpath = os.path.join(os.environ['ROAM_APPPATH'], 'log')
 except KeyError:
-   #running from source
-   logpath = os.path.join(
-                os.path.dirname(
-                   os.path.dirname(
-                      os.path.dirname(
-                         os.path.realpath(__file__)))), 'log')
+   logpath = 'log' 
 
 if not os.path.exists(logpath):
    os.makedirs(logpath)


### PR DESCRIPTION
run_linux.sh sets ROAM_APPPATH.  utils and logger create log Directory relative to APPPATH instead of cwd if the path is set.  This results in no behavior Change for Windows, but assures that log is created in the right place if roam is called from a different Directory on Linux.

What this really Needs, though, is for apppath to be set in main or environ and made available through the api.  It's really awkward to get at it from utils. 
