### PR TITLE
Remove unused and failing import of contextmanagers

### DIFF
--- a/src/roam/api/utils.py
+++ b/src/roam/api/utils.py
@@ -2,7 +2,7 @@ import sys
 import os
 import subprocess
 from contextlib import contextmanager
-from qgis.core import QgsMapLayerRegistry, contextmanagers, QgsFeatureRequest, QgsGeometry
+from qgis.core import QgsMapLayerRegistry, QgsFeatureRequest, QgsGeometry
 from qgis.gui import QgsMessageBar
 from PyQt4.QtCore import QPyNullVariant
 from roam.structs import CaseInsensitiveDict


### PR DESCRIPTION
I think this Import just got in there by mistake.  It doesn't work on Windows or Linux, and it doesn't seem to be used.  ?

Traceback (most recent call last):
  File "**main**.py", line 23, in <module>
  File "roam\mainwindow.pyc", line 40, in <module>
    QLabel {
  File "roam\dataentrywidget.pyc", line 11, in <module>

  File "roam\editorwidgets\featureformwidget.pyc", line 9, in <module>

  File "roam\api__init__.pyc", line 5, in <module>

  File "roam\api\featureform.pyc", line 37, in <module>
  File "roam\api\utils.pyc", line 5, in <module>

ImportError: cannot import name contextmanager
