### PR TITLE
Ignore non project folders

### DIFF
--- a/src/roam/project.py
+++ b/src/roam/project.py
@@ -135,6 +135,11 @@ def getProjects(paths):
                     # Ignore hidden folders.
                     continue
 
+            for folder in folders:
+                if os.path.basename(folder).startswith("."):
+                    # Ignore hidden folders.
+                    continue
+
                 if not initfound(folder):
                     createinifile(folder)
 


### PR DESCRIPTION
Some sync programs (i.e. ressilio and syncthing) add folders to track changes which start with '.'. These folders are incorrectly then detected as valid project folders and displayed in the app. This commit bypasses this issue.