### PR TITLE
GPS Logging Fix

### DIFF
--- a/src/roam/gpslogging.py
+++ b/src/roam/gpslogging.py
@@ -1,5 +1,8 @@
 import getpass
+import uuid
+from datetime import datetime
 
+import roam.config
 from qgis.PyQt.QtCore import Qt, pyqtSignal, QObject, QDateTime
 from qgis.core import QgsFeature, QgsGeometry, QgsPointXY
 
@@ -17,8 +20,22 @@ class GPSLogging(QObject):
         self.featurecache = []
         self._tracking = False
         self.gps.gpsposition.connect(self.postionupdated)
+        #Get tracklog interval settings
+        self.tracking_settings = roam.config.settings['gps']['tracking']
+        #Add unique track id
+        self.tracking_settings['trackid'] = str(uuid.uuid4())
+        #Setup initial tracking value
+        if hasattr(self.tracking_settings, 'distance'):
+            #Default to 0,0 for distance based tracking
+            self.tracking_settings['last'] = QgsPointXY(0,0)
+        else:
+            #Default to epoch for time based tracking
+            self.tracking_settings['last'] = 0
 
     def enable_logging_on(self, layer):
+        #Enable logging
+        self.logging = True
+        #Setup layer and provider
         self.layer = layer
         self.layerprovider = self.layer.dataProvider()
         self.fields = self.layerprovider.fields()
@@ -44,8 +61,33 @@ class GPSLogging(QObject):
         self.trackingchanged.emit(value)
 
     def postionupdated(self, position: QgsPointXY, info):
-        if not self.logging or not self.layer or not self.layerprovider:
+        #Check layer for logging capability and if in logging mode
+        if not self.logging or not self.layer or not self.layerprovider or not self.tracking_settings:  
             return
+        #Check tracking setting type
+        if hasattr(self.tracking_settings, 'distance'):
+            #Get tracking interval
+            tracking_interval = getattr(self.tracking_settings, 'distance')
+            #Compare distance
+            if position.distance(self.tracking_settings['last']) >= tracking_interval:
+                #Log track element
+                self.log_track(position, info)
+                #Update last position
+                self.tracking_last = position
+        else:      
+            #Get tracking interval (default to time 1 sec)
+            tracking_interval = getattr(self.tracking_settings, 'time', 1)
+            #Get current timestamp
+            now = datetime.timestamp(datetime.now())
+            #Compare timestamp
+            if (now - self.tracking_settings['last']) > tracking_interval:
+                #Log track element
+                self.log_track(position, info)
+                #Update last position
+                self.tracking_last = now
+
+    #Seprate log_track function to allow for multiple types of log intervals
+    def log_track(self, position: QgsPointXY, info):
 
         feature = QgsFeature()
         feature.setFields(self.fields)
@@ -58,6 +100,8 @@ class GPSLogging(QObject):
                 value = QDateTime.currentDateTime().toString(Qt.ISODate)
             elif name == 'user':
                 value = getpass.getuser()
+            elif name == 'trackid':
+                value = self.tracking_settings['trackid']
             else:
                 try:
                     value = self.gps.gpsinfo(name)

--- a/src/roam/settingswidget.py
+++ b/src/roam/settingswidget.py
@@ -91,6 +91,9 @@ class SettingsWidget(Ui_settingsWidget, QWidget):
 
     def gpsPortCombo_currentIndexChanged(self, index):
         port = self.gpsPortCombo.itemText(index)
+        #If os returns port name with colon and label, strip label (noted in Windows 7)
+        if ':' in port:
+            port = port.split(':')[0]
         self.settings["gpsport"] = port
         self.notifysettingsupdate()
 


### PR DESCRIPTION
#181 was closed incorrectly, and the issue was recently brought up at stack exchange https://gis.stackexchange.com/questions/339097/intramaps-roam-gps-log-not-honoring-tracking-settings

Prior to #389 the update frequency of the marker on the map and addition of points to gps_log were based on the GPS frequency. #389 hard coded this at 1 second to account for newer receivers with high update rates.

This PR enables time and distance limits between points in the gps tracklog, honouring roam settings.

Also added a related fix for some systems (Lenovo + Windows 7 + QGIS3) when the COM port in settings combo box is displayed with a label. Before saving to settings, the label is removed from the comm port.