### PR TITLE
Update Port Combo in Settings

### DIFF
--- a/src/roam/settingswidget.py
+++ b/src/roam/settingswidget.py
@@ -90,6 +90,9 @@ class SettingsWidget(Ui_settingsWidget, QWidget):
         self.notifysettingsupdate()
 
     def gpsPortCombo_currentIndexChanged(self, index):
+        #If os returns port name with colon and label, strip label (noted in Windows 7)
+        if ':' in port:
+            port = port.split(':')[0]
         port = self.gpsPortCombo.itemText(index)
         self.settings["gpsport"] = port
         self.notifysettingsupdate()


### PR DESCRIPTION
When listing ports, Roam displays the port name and label in the combobox on my development setup (Windows 7 Lenovo QGIS3 Py3). The problem is that once selected, the name and label is then used to connect to the gps device which fails. This change looks for a colon and if it has one, removes the trailing label.